### PR TITLE
Esdc error

### DIFF
--- a/src/esdc.jl
+++ b/src/esdc.jl
@@ -43,7 +43,11 @@ function esdd(; bucket = nothing, store = nothing, res = "low", chunks = "ts", r
 
   if version === nothing
     if region == "global"
-      version = 3
+      if res == "high"
+        version = 2
+      else
+        version = 3
+      end
     elseif region == "Colombia"
       version = 2
     end
@@ -53,12 +57,12 @@ function esdd(; bucket = nothing, store = nothing, res = "low", chunks = "ts", r
 
   # give a sensible error if key does not exist
   if !haskey(cubesdict, k)
-    @info "possible keys are" keys(cubesdict)
-    error("key $(k) does not exist")
+      @info "possible keys are" keys(cubesdict)
+      error("key $(k) does not exist")
   end
+  b, s = cubesdict[k]
 
   # switch out defaults
-  b, s = cubesdict[k]
   if bucket === nothing
     bucket = b
   end

--- a/test/access.jl
+++ b/test/access.jl
@@ -1,4 +1,5 @@
 using Dates
+import DimensionalData
 
 c=Cube()
 
@@ -126,4 +127,22 @@ end
 
   c = esdd(res="tiny")
   c.gross_primary_productivity[time=DD.Near(DateTime(2005))].data[44,14] == 2.3713999f0
+end
+
+@testset "regions work" begin
+    c1 = esdc(region = "Colombia")
+    @test DimensionalData.bounds(c1, :lon) == (-82.9587215, -60.0421465)
+    @test DimensionalData.bounds(c1, :lat) == (-13.957917500000002, 13.9586375)
+
+    c2 = esdc() # global low resolution
+    @test DimensionalData.bounds(c2, :lon) == (-179.875, 179.875)
+    @test DimensionalData.span(c2, :lon).step == 0.25
+
+    c3 = esdc(res = "high", version = 2) # global high resolution
+    @test DimensionalData.bounds(c3, :lon) == (-179.95833333333331, 179.95833333333331)
+    @test DimensionalData.span(c3, :lon).step == 0.08333333333333333
+
+    c4 = esdc(res = "tiny") # global tiny cube
+    @test DimensionalData.span(c4, :lon).step == 2.5
+    @test DimensionalData.bounds(c4, :lon) == (-178.75, 178.75)
 end

--- a/test/access.jl
+++ b/test/access.jl
@@ -129,7 +129,7 @@ end
   c.gross_primary_productivity[time=DD.Near(DateTime(2005))].data[44,14] == 2.3713999f0
 end
 
-@testset "regions work" begin
+@testset "esdd smarts" begin
     c1 = esdc(region = "Colombia")
     @test DimensionalData.bounds(c1, :lon) == (-82.9587215, -60.0421465)
     @test DimensionalData.bounds(c1, :lat) == (-13.957917500000002, 13.9586375)
@@ -138,7 +138,7 @@ end
     @test DimensionalData.bounds(c2, :lon) == (-179.875, 179.875)
     @test DimensionalData.span(c2, :lon).step == 0.25
 
-    c3 = esdc(res = "high", version = 2) # global high resolution
+    c3 = esdc(res = "high") # global high resolution
     @test DimensionalData.bounds(c3, :lon) == (-179.95833333333331, 179.95833333333331)
     @test DimensionalData.span(c3, :lon).step == 0.08333333333333333
 


### PR DESCRIPTION
addresses #301 

Prevents `esdd()` from silently falling back to an unexpected default cube.